### PR TITLE
Fix IAsyncDisposable compatibility issues with .NET Core 3.0

### DIFF
--- a/ComposableAsync.Concurrent/IStoppableFiber.cs
+++ b/ComposableAsync.Concurrent/IStoppableFiber.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace ComposableAsync.Concurrent
+﻿namespace ComposableAsync.Concurrent
 {
     /// <summary>
     /// Fiber that can be stopped

--- a/ComposableAsync.Core/ComposableAsync.Core.csproj
+++ b/ComposableAsync.Core/ComposableAsync.Core.csproj
@@ -4,12 +4,12 @@
     <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
     <RootNamespace>ComposableAsync</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
     <Authors>David Desmaisons</Authors>
     <Product />
     <Company />
-    <AssemblyVersion>1.1.0.0</AssemblyVersion>
-    <FileVersion>1.1.0.0</FileVersion>
+    <AssemblyVersion>1.1.1.0</AssemblyVersion>
+    <FileVersion>1.1.1.0</FileVersion>
     <PackageProjectUrl>http://david-desmaisons.github.io/ComposableAsync/</PackageProjectUrl>
     <RepositoryUrl>http://david-desmaisons.github.io/ComposableAsync/</RepositoryUrl>
     <PackageTags>Asynchronous,Parallel,Task</PackageTags>

--- a/ComposableAsync.Core/DispatcherManager/IDispatcherManager.cs
+++ b/ComposableAsync.Core/DispatcherManager/IDispatcherManager.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace ComposableAsync
+﻿namespace ComposableAsync
 {
     /// <summary>
     /// Dispatcher manager

--- a/ComposableAsync.Core/DispatcherManager/MonoDispatcherManager.cs
+++ b/ComposableAsync.Core/DispatcherManager/MonoDispatcherManager.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 
 namespace ComposableAsync
 {

--- a/ComposableAsync.Core/Disposable/ComposableAsyncDisposable.cs
+++ b/ComposableAsync.Core/Disposable/ComposableAsyncDisposable.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using System.Linq;
 using System.Threading.Tasks;
 

--- a/ComposableAsync.Core/Disposable/IAsyncDisposable.cs
+++ b/ComposableAsync.Core/Disposable/IAsyncDisposable.cs
@@ -1,6 +1,6 @@
 ﻿using System.Threading.Tasks;
 
-namespace System
+namespace ComposableAsync
 {
     /// <summary>
     ///  Asynchronous version of IDisposable

--- a/Tests/ComposableAsync.Concurrent.Test/TaskPoolActorFactoryTest.cs
+++ b/Tests/ComposableAsync.Concurrent.Test/TaskPoolActorFactoryTest.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
 using ComposableAsync.Factory;
 using ComposableAsync.Factory.Test.TestInfra.DummyClass;
@@ -7,7 +6,7 @@ using FluentAssertions;
 using Xunit;
 
 namespace ComposableAsync.Concurrent.Test
-{     
+{
     public class TaskPoolActorFactoryTest
     {
         private readonly IProxyFactory _TaskPoolActorFactory;

--- a/Tests/ComposableAsync.Factory.Test/TestInfra/DummyClass/IDummyInterface4.cs
+++ b/Tests/ComposableAsync.Factory.Test/TestInfra/DummyClass/IDummyInterface4.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace ComposableAsync.Factory.Test.TestInfra.DummyClass
+﻿namespace ComposableAsync.Factory.Test.TestInfra.DummyClass
 {
     public interface IDummyInterface4: IDummyInterface1, IAsyncDisposable
     {


### PR DESCRIPTION
Suggested fix for issue #5.

The .NET Core [System.IAsyncDisposable](https://github.com/dotnet/runtime/blob/master/src/libraries/System.Private.CoreLib/src/System/IAsyncDisposable.cs) interface defines DiposeAsync() as returning a ValueTask, not a Task. Moving the namespace appears to be an easy fix to resolve the conflict - all tests pass and consuming code will now compile.